### PR TITLE
Add functionality to render JSON from twig file

### DIFF
--- a/select2/fieldtypes/Select2FieldType.php
+++ b/select2/fieldtypes/Select2FieldType.php
@@ -83,16 +83,33 @@ class Select2FieldType extends BaseFieldType
     public function getJsonFileOptions($list, $json = null)
     {
 	    
-        // Get List	    
-	    if ($list === 'json') {
-	        $jsonList = $this->getJsonFolderPath() . $json;		    
-	    }
-	    else {
-	        $jsonList = UrlHelper::getResourceUrl('select2/json/' . $list . '.json');
-	    }
+        if ($list === 'jsonTwig') {
+            
+            // Record original templates path
+            $originalPath = craft()->path->getTemplatesPath();
+            
+            $path = craft()->path->getSiteTemplatesPath();
 
-        // Get List Contents
-        $json = file_get_contents($jsonList);
+            // Set new path for twig render
+            craft()->path->setTemplatesPath($path);
+            $jsonList = craft()->templates->render('select2/athletes.json');
+
+            // Set templates path back to original
+            craft()->path->setTemplatesPath($originalPath);
+        } 
+        else {
+        
+            // Get List	    
+            if ($list === 'json') {
+                $jsonList = $this->getJsonFolderPath() . $json;		    
+            }
+            else {
+                $jsonList = UrlHelper::getResourceUrl('select2/json/' . $list . '.json');
+            }
+
+            // Get List Contents
+            $json = file_get_contents($jsonList);
+        }
         
         // Decode to Array
 		return json_decode($json, TRUE);

--- a/select2/templates/field/settings.twig
+++ b/select2/templates/field/settings.twig
@@ -11,6 +11,7 @@
     required: true,
     options: {
 		'json': 'JSON',
+		'jsonTwig' : 'JSON (Twig)',
 		'countries': 'Countries',
 		'countries': 'Countries',
 		'countriesIso2': 'Countries (2 Digit ISO)',
@@ -23,7 +24,7 @@
     }
 }) }}
 
-<div class="js-select2-json{% if select2ListValue == 'json'%} is-visible{% endif %}">
+<div class="js-select2-json{% if select2ListValue == 'json' or select2ListValue == 'jsonTwig' %} is-visible{% endif %}">
 	{% if jsonFiles|length %}
 		{{ forms.selectField({
 		    label: 'JSON File',


### PR DESCRIPTION
Maybe I'm the only one who needed this but, this PR allows the JSON files to be dynamic. There's another option in the JSON source settings now for `JSON (Twig)`, but theoretically, you could get away with ditching the `file_get_contents()` method altogether and just using twig render. Maybe the current way has significant performance advantages I'm unaware of.