### PR TITLE
Made getInputHtml $value param empty string

### DIFF
--- a/select2/fieldtypes/Select2FieldType.php
+++ b/select2/fieldtypes/Select2FieldType.php
@@ -104,14 +104,12 @@ class Select2FieldType extends BaseFieldType
      *
 	 * @return mixed
      */
-    public function getInputHtml($name, $value)
+    public function getInputHtml($name, $value = '')
     {
-        if (!$value) $value = new Select2Model();
+	// Get Field Settings
+	$settings = $this->getSettings();
 
-		// Get Field Settings
-		$settings = $this->getSettings();
-
-		// Reformat the input name into something that looks more like an ID
+	// Reformat the input name into something that looks more like an ID
         $id = craft()->templates->formatInputId($name);
         
         // Figure out what that ID is going to look like once it has been namespaced


### PR DESCRIPTION
When `$value` was `false` it was being set to an instance of `Select2Model.`. Which is unable to be converted to a string on line #144 in the `$fieldOptions` array.